### PR TITLE
Impl std::error::Error for Error

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -42,6 +42,9 @@ pub enum Error {
     InsufficientBytes(usize),
 }
 
+impl std::error::Error for Error {
+}
+
 /// MQTT packet type
 #[repr(u8)]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]


### PR DESCRIPTION
I needed to have your Error type implement std::error::Error.